### PR TITLE
future fix with add of `glClear(GL_COLOR_BUFFER_BIT);`

### DIFF
--- a/screensaver.stars/addon.xml.in
+++ b/screensaver.stars/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.stars"
-  version="2.1.0"
+  version="2.1.1"
   name="Stars"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/StarField.cpp
+++ b/src/StarField.cpp
@@ -230,6 +230,9 @@ int CStarField::Create(int iWidth, int iHeight)
 
   glGenBuffers(1, &m_vertexVBO);
   glGenBuffers(1, &m_indexVBO);
+
+  glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
 #endif
 
   return 0;
@@ -426,6 +429,8 @@ void CStarField::DoDraw(void)
 #ifndef WIN32
   if (!m_shader)
     return;
+
+  glClear(GL_COLOR_BUFFER_BIT);
 
   size_t nVSize = m_nDrawnStars * POINTSPERSTAR;
   GLint posLoc = m_shader->GetPosLoc();


### PR DESCRIPTION
In future the `glClear(GL_COLOR_BUFFER_BIT);` call becomes removed from Kodi.